### PR TITLE
Check log level before delegating to go-logging

### DIFF
--- a/log.go
+++ b/log.go
@@ -151,26 +151,41 @@ type Logger struct {
 
 // Debug implements the logger interface
 func (l Logger) Debug(v ...interface{}) {
+	if !l.logger.IsEnabledFor(gologging.DEBUG) {
+		return
+	}
 	l.logger.Debug(v...)
 }
 
 // Info implements the logger interface
 func (l Logger) Info(v ...interface{}) {
+	if !l.logger.IsEnabledFor(gologging.INFO) {
+		return
+	}
 	l.logger.Info(v...)
 }
 
 // Warning implements the logger interface
 func (l Logger) Warning(v ...interface{}) {
+	if !l.logger.IsEnabledFor(gologging.WARNING) {
+		return
+	}
 	l.logger.Warning(v...)
 }
 
 // Error implements the logger interface
 func (l Logger) Error(v ...interface{}) {
+	if !l.logger.IsEnabledFor(gologging.ERROR) {
+		return
+	}
 	l.logger.Error(v...)
 }
 
 // Critical implements the logger interface
 func (l Logger) Critical(v ...interface{}) {
+	if !l.logger.IsEnabledFor(gologging.CRITICAL) {
+		return
+	}
 	l.logger.Critical(v...)
 }
 

--- a/log.go
+++ b/log.go
@@ -66,7 +66,7 @@ func NewLogger(cfg config.ExtraConfig, ws ...io.Writer) (logging.Logger, error) 
 		logConfig.Prefix = ""
 	}
 
-	backends := []gologging.Backend{}
+	var backends []gologging.Backend
 	for _, w := range ws {
 		var pattern string
 		var prefix string


### PR DESCRIPTION
Check the logger log level before calling the go-logging method. This improves performance.